### PR TITLE
Added mime types for markdown, WMA, JPEG-XR, and CSV files

### DIFF
--- a/mime.types
+++ b/mime.types
@@ -30,6 +30,7 @@ types {
     audio/mp4                             aac f4a f4b m4a;
     audio/mpeg                            mp3;
     audio/ogg                             oga ogg opus;
+    audio/x-ms-wma                        wma;
     audio/x-realaudio                     ra;
     audio/x-wav                           wav;
     image/bmp                             bmp;
@@ -38,6 +39,7 @@ types {
     image/png                             png;
     image/svg+xml                         svg svgz;
     image/tiff                            tif tiff;
+    image/vnd.ms-photo                    jxr;
     image/vnd.wap.wbmp                    wbmp;
     image/webp                            webp;
     image/x-jng                           jng;
@@ -122,7 +124,9 @@ types {
     application/xslt+xml                  xsl;
     application/zip                       zip;
     text/css                              css;
+    text/csv                              csv;
     text/html                             htm html shtml;
+    text/markdown                         md;
     text/mathml                           mml;
     text/plain                            txt;
     text/vcard                            vcard vcf;


### PR DESCRIPTION
I added the MIME types for markdown text, Windows Media Audio (WMA – which is still widespread, moreso than RealAudio, for example), new-ish JPEG-XR image format supported by MS Edge and IE 9+, and CSV files, given their popularity and the new W3C HTML with CSV spec. All of the MIME types I added are official IANA types except for the MS formats, which have the vendor syntax. Here's a source for the JPEG-XR type: https://developer.microsoft.com/en-us/microsoft-edge/testdrive/demos/picture/ (Note that you already have Windows Media Video (WMV), but not the WMA audio).
